### PR TITLE
Update rake dependency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,15 +37,14 @@ Style/MixinUsage:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 100
-
 Metrics/MethodLength:
   Max: 50
 
-Style/AlignHash:
+Layout/HashAlignment:
   Description: "Align the elements of a hash literal if they span more than one line."
   Enabled: true
   EnforcedHashRocketStyle: table
   EnforcedColonStyle: table
 
+Layout/LineLength:
+  Max: 100

--- a/lib/wispro/version.rb
+++ b/lib/wispro/version.rb
@@ -1,3 +1,3 @@
 module Wispro
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end

--- a/wispro.gemspec
+++ b/wispro.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.17'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.8'
   spec.add_development_dependency 'rubocop', '~> 0.73'
   spec.add_development_dependency 'webmock', '~> 3.6'


### PR DESCRIPTION
# What
Update `rake` to fix CVE-2020-8130